### PR TITLE
Output service method in list API (#1523)

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -746,8 +746,9 @@ manager_recv_cb(EV_P_ ev_io *w, int revents)
         cork_hash_table_iterator_init(server_table, &iter);
         while ((entry = cork_hash_table_iterator_next(&iter)) != NULL) {
             struct server *server = (struct server *)entry->value;
+            char *method = server->method?server->method:manager->method;
             size_t pos = strlen(buf);
-            size_t entry_len = strlen(server->port)+strlen(server->password);
+            size_t entry_len = strlen(server->port) + strlen(server->password) + strlen(method);
             if (pos > BUF_SIZE-entry_len-50) {
                 if (sendto(manager->fd, buf, pos, 0, (struct sockaddr *)&claddr, len)
                     != pos) {
@@ -756,7 +757,9 @@ manager_recv_cb(EV_P_ ev_io *w, int revents)
                 memset(buf, 0, BUF_SIZE);
                 pos = 0;
             }
-            sprintf(buf + pos, "\n\t{\"server_port\":\"%s\",\"password\":\"%s\"},", server->port,server->password);
+            sprintf(buf + pos, "\n\t{\"server_port\":\"%s\",\"password\":\"%s\",\"method\":\"%s\"},", 
+                    server->port,server->password,method);
+
         }
 
         size_t pos = strlen(buf);


### PR DESCRIPTION
* Fix #1518 config file with wrong json format

Removing trailing "," to make the configuration file compliant with JSON specification

* Remove extra "," in json file

* server_port should be integer instead of string 

server_port in generated json configuration file should be integer instead of string

* Add list active service ports feature

A new management API has been added to list all active service ports.

* Make list API output JSON compliant 

In the following format:
[
{ "server_port":"8388","password":"password"},
...
]
Note that server_port value is string instead of integer for easy display on the console.

* Make safe room for the new list entry

"\n\t{\"server_port\":\"%s\",\"password\":\"%s\"}," 
Reserve 50 char spaces for the extra characters in the above.

* Output method for each service port in list API